### PR TITLE
chore(ci): fix artifact action v4 and stabilize collector workflow

### DIFF
--- a/.github/workflows/collector-test.yml
+++ b/.github/workflows/collector-test.yml
@@ -10,6 +10,7 @@ on:
     branches: [ main ]
     paths:
       - 'apps/collector/**'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -32,8 +33,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-        cache-dependency-path: apps/collector/package-lock.json
     
     - name: Install dependencies
       run: npm ci
@@ -68,8 +67,10 @@ jobs:
         LOG_LEVEL: error
     
     - name: Run E2E API tests
-      run: node test-api-final.js
-      continue-on-error: false
+      if: ${{ secrets.KRA_SERVICE_KEY != '' }}
+      env:
+        KRA_SERVICE_KEY: ${{ secrets.KRA_SERVICE_KEY }}
+      run: npm run test:kra
     
     - name: Check API health
       run: |
@@ -77,6 +78,9 @@ jobs:
         curl -f http://localhost:3001/api/v1 || exit 1
     
     - name: Test critical endpoints
+      if: ${{ secrets.KRA_SERVICE_KEY != '' }}
+      env:
+        KRA_SERVICE_KEY: ${{ secrets.KRA_SERVICE_KEY }}
       run: |
         # Test Race API
         curl -f "http://localhost:3001/api/v1/races/20240106/서울/1" || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
         fail_ci_if_error: false
     
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results


### PR DESCRIPTION
- test.yml: upgrade actions/upload-artifact to v4 to avoid deprecation failure on setup stage\n- collector-test.yml: remove invalid npm cache path, add workflow_dispatch, gate KRA-dependent steps behind secrets.KRA_SERVICE_KEY, and run Jest-based e2e\n\nThis should fix recent CI failures:\n- Test KRA API v2 failing at Set up job due to deprecated actions/upload-artifact@v3\n- NodeJS Collector API Tests failing at setup-node cache path resolution (no lockfile path)