### PR TITLE
fix(security): validate database pooler host structurally

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: javascript, python
-          queries: security-and-quality
+          # Ruff and mypy own code-quality checks. Keep CodeQL focused on
+          # actionable security findings, including the extended query suite.
+          queries: security-extended
       - name: Run CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/apps/api/infrastructure/database.py
+++ b/apps/api/infrastructure/database.py
@@ -17,6 +17,7 @@ from infrastructure.migration_manifest import (
     get_active_migration_names,
     get_required_migration_head,
 )
+from utils.database_url import is_supabase_pooler_url
 
 logger = structlog.get_logger()
 
@@ -65,7 +66,7 @@ if "sqlite" in database_url:
     engine = create_async_engine(database_url, echo=settings.debug)
 else:
     # For Supabase/pgbouncer, use NullPool to avoid connection pooling issues
-    if "pooler.supabase.com" in database_url:
+    if is_supabase_pooler_url(database_url):
         engine = create_async_engine(
             database_url,
             echo=settings.debug,

--- a/apps/api/scripts/test_db_connection.py
+++ b/apps/api/scripts/test_db_connection.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config import settings
+from utils.database_url import is_supabase_pooler_url
 
 logger = structlog.get_logger()
 
@@ -101,7 +102,7 @@ async def test_sqlalchemy_connection():
         # infrastructure/database.py와 동일한 설정
         db_url = settings.database_url
 
-        if "pooler.supabase.com" in db_url:
+        if is_supabase_pooler_url(db_url):
             base_url = db_url.split("?")[0]
             from sqlalchemy.pool import NullPool
 

--- a/apps/api/tests/test_kra_api.py
+++ b/apps/api/tests/test_kra_api.py
@@ -5,11 +5,7 @@ import os
 from urllib.parse import unquote
 
 import requests
-import urllib3
 from dotenv import load_dotenv
-
-# SSL 경고 비활성화
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # 환경 변수 로드
 load_dotenv()
@@ -44,11 +40,11 @@ params = {
 
 print(f"\nTesting KRA API with date: {test_date}")
 print(f"URL: {url}")
-print(f"Params: {params}")
+safe_params = {**params, "serviceKey": "<redacted>"}
+print(f"Params: {safe_params}")
 
 try:
-    # SSL 검증 비활성화 (개발 환경용)
-    response = requests.get(url, params=params, verify=False, timeout=30)
+    response = requests.get(url, params=params, timeout=30)
     print(f"\nStatus Code: {response.status_code}")
 
     if response.status_code == 200:

--- a/apps/api/tests/unit/test_database_url.py
+++ b/apps/api/tests/unit/test_database_url.py
@@ -1,0 +1,23 @@
+from utils.database_url import is_supabase_pooler_url
+
+
+def test_recognizes_supabase_pooler_hosts():
+    assert is_supabase_pooler_url(
+        "postgresql+asyncpg://user:pass@aws-0-ap-northeast-2.pooler.supabase.com/db"
+    )
+    assert is_supabase_pooler_url("postgresql://user@pooler.supabase.com/db")
+
+
+def test_rejects_pooler_text_outside_hostname():
+    assert not is_supabase_pooler_url(
+        "postgresql://pooler.supabase.com@attacker.example/db"
+    )
+    assert not is_supabase_pooler_url("postgresql://db.example/pooler.supabase.com")
+    assert not is_supabase_pooler_url(
+        "postgresql://pooler.supabase.com.attacker.example/db"
+    )
+
+
+def test_handles_invalid_or_case_variant_urls():
+    assert is_supabase_pooler_url("POSTGRESQL://user@AWS-0.POOLER.SUPABASE.COM./db")
+    assert not is_supabase_pooler_url("not-a-database-url")

--- a/apps/api/utils/database_url.py
+++ b/apps/api/utils/database_url.py
@@ -1,0 +1,18 @@
+"""Helpers for making decisions from parsed database URLs."""
+
+from urllib.parse import urlsplit
+
+
+def is_supabase_pooler_url(database_url: str) -> bool:
+    """Return whether the URL targets Supabase's pooler domain.
+
+    Parse the hostname instead of searching the entire URL so credentials, paths,
+    and query parameters cannot spoof the pooler classification.
+    """
+    hostname = urlsplit(database_url).hostname
+    if hostname is None:
+        return False
+    hostname = hostname.rstrip(".").lower()
+    return hostname == "pooler.supabase.com" or hostname.endswith(
+        ".pooler.supabase.com"
+    )


### PR DESCRIPTION
## Summary
- classify Supabase pooler connections from the parsed hostname instead of an arbitrary URL substring
- share the hostname check with the database diagnostic script and add spoofing regression coverage
- restore TLS verification and redact API-key parameters in the manual KRA diagnostic
- focus CodeQL on `security-extended`; Ruff and mypy remain the quality gates

## Security impact
Prevents credentials, paths, or query text from spoofing the pooler host policy, removes a TLS-verification bypass, and stops diagnostic credential disclosure. This remediates the three security findings still active in the current CodeQL analysis.

## Verification
- focused pytest: 6 passed across URL and workflow boundary tests
- Ruff check + format check
- mypy for the URL utility
- staged gitleaks scan: no leaks